### PR TITLE
Basic attribute matching with CSS selectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
 # End libxmljs work-arounds
 
 node_js:
-    - "0.10"
-    - "iojs-2.5"
     - "4"
     - "5"
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ var matches = matcher.matchAll(testDoc, { isXML: false });
 
 Using [the Barack Obama
 article](https://en.wikipedia.org/api/rest_v1/page/html/Barack_Obama) (1.5mb HTML, part of `npm test`):
-- `elematch` match & replace all 32 `<figure>` elements: 1.78ms
-- `elematch` match & replace all 32 `<figure>` elements, isXML: 1.66ms
-- `elematch` match & replace all 1852 links: 19.52ms
-- `elematch` match & replace all 1852 links, isXML: 11.57ms
-- `elematch` match & replace a specific link (`a[href="./Riverdale,_Chicago"]`): 2.0ms
-- `elematch` match & replace a specific link (`a[href="./Riverdale,_Chicago"]`), isXML: 1.96ms
+- `elematch` match & replace all 32 `<figure>` elements: 1.74ms
+- `elematch` match & replace all 32 `<figure>` elements, isXML: 1.65ms
+- `elematch` match & replace all 1852 links: 12.78ms
+- `elematch` match & replace all 1852 links, isXML: 11.14ms
+- `elematch` match & replace a specific link (`a[href="./Riverdale,_Chicago"]`): 1.92ms
+- `elematch` match & replace a specific link (`a[href="./Riverdale,_Chicago"]`), isXML: 1.89ms
 - `elematch` match & replace references section (`ol[typeof="mw:Extension/references"]`): 3.4ms
 - `elematch` match & replace references section (`ol[typeof="mw:Extension/references"]`), isXML: 3.3ms
 - `libxml` DOM parse: 26.3ms

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ Matcher.prototype._makeMatchers = function(spec) {
                             return '(?:' + pattern + ')';
                         })
                         .join('|')
-                    + ')[a-zA-Z][a-zA-Z_-]*' + remainingTagPattern + '[^<]*)+', 'g');
+                    + ')[a-zA-Z][a-zA-Z_-]*' + remainingTagPattern + '[^<]*)*', 'g');
 
     // A matcher for the tags we *are* actually interested in.
     this._matchRe = new RegExp('<(\\/?)(?:'
@@ -66,6 +66,32 @@ Matcher.prototype._makeMatchers = function(spec) {
                         })
                         .join('|')
                     + ')' + remainingTagAssertionPattern, 'g');
+};
+
+var attrValReplacements = {
+    'double': {
+        '<': '(?:<|&lt;)',
+        '>': '(?:>|&lt;)',
+        '&': '(?&|&amp;)',
+        '"': '&quot;',
+        "'": '(?:\'|&apos;|&#39;)',
+    }
+};
+attrValReplacements.single = Object.assign({},
+    attrValReplacements.double, {
+        '"': '(?:"|&quot;)',
+        "'": '(?:\'|&apos;|&#39;)',
+    });
+
+Matcher.prototype._quoteAttributeValue = function(s, mode) {
+    if (/[<'">&]/.test(s)) {
+        var map = attrValReplacements[mode];
+        return s.replace(/[<'">&]/g, function(m) {
+                return map[m];
+        });
+    } else {
+        return s;
+    }
 };
 
 Matcher.prototype._compileTagMatcher = function(handler) {
@@ -90,10 +116,23 @@ Matcher.prototype._compileTagMatcher = function(handler) {
         }
         // Only match on the first attribute
         var attr = attributes[0];
+        // TODO: Support XML vs. HTML escaping flavors!
+        var escapedValue = '';
+        var value = attr.value || '';
+
+
+        var doubleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'double');
+        var singleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'single');
+
         if (!attr.operator) {
-            res += '(?=[^>]*?\\s' + attr.name + '=["\'][^"\']*["\'])';
+            res += '(?=[^>]*?\\s' + attr.name + '=(?:"[^"]*"|\'[^\']*\'))';
         } else if (attr.operator === '=') {
-            res += '(?=[^>]*?\\s' + attr.name + '=["\']' + attr.value + '["\'])';
+            res += '(?=[^>]*?\\s' + attr.name + '=(?:"' + doubleQuoteValuePattern + '"|\''
+                        + singleQuoteValuePattern + '\'))';
+        } else if (attr.operator === '^=') {
+            res += '(?=[^>]*?\\s' + attr.name
+                    + '=(?:"' + doubleQuoteValuePattern + '[^"]*"'
+                    + '|\'' + singleQuoteValuePattern + '[^\']*\'';
         } else {
             throw new Error("Unsupported attribute predicate: " + attr.operator);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var entities = new Entities();
 var CssSelectorParser = require('css-selector-parser').CssSelectorParser;
 var cssParser = new CssSelectorParser();
 cssParser.registerSelectorPseudos('has');
+cssParser.registerAttrEqualityMods('^', '~', '$', '*');
 
 // Shared patterns
 var optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:"[^"]*"|\'[^\']*\'))?)*';
@@ -71,7 +72,7 @@ Matcher.prototype._makeMatchers = function(spec) {
 var attrValReplacements = {
     'double': {
         '<': '(?:<|&lt;)',
-        '>': '(?:>|&lt;)',
+        '>': '(?:>|&gt;)',
         '&': '(?&|&amp;)',
         '"': '&quot;',
         "'": '(?:\'|&apos;|&#39;)',
@@ -132,7 +133,19 @@ Matcher.prototype._compileTagMatcher = function(handler) {
         } else if (attr.operator === '^=') {
             res += '(?=[^>]*?\\s' + attr.name
                     + '=(?:"' + doubleQuoteValuePattern + '[^"]*"'
-                    + '|\'' + singleQuoteValuePattern + '[^\']*\'';
+                    + '|\'' + singleQuoteValuePattern + '[^\']*\'))';
+        } else if (attr.operator === '$=') {
+            res += '(?=[^>]*?\\s' + attr.name
+                    + '=(?:"[^"]*' + doubleQuoteValuePattern + '"'
+                    + '|\'[^\']*' + singleQuoteValuePattern + '\'))';
+        } else if (attr.operator === '~=') {
+            res += '(?=[^>]*?\\s' + attr.name
+                    + '=(?:"(?:[^"]+\\s+)*' + doubleQuoteValuePattern + '(?:\\s+[^"]+)*"'
+                    + "|'(?:[^']+\\s)*" + singleQuoteValuePattern + "(?:\\s[^']+)*'))";
+        } else if (attr.operator === '*=') {
+            res += '(?=[^>]*?\\s' + attr.name
+                    + '=(?:"[^"]*' + doubleQuoteValuePattern + '[^"]*"'
+                    + "|'[^']*" + singleQuoteValuePattern + "[^']*'))";
         } else {
             throw new Error("Unsupported attribute predicate: " + attr.operator);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,89 +1,93 @@
 'use strict';
 
-var Entities = require('html-entities').AllHtmlEntities
+var Entities = require('html-entities').AllHtmlEntities;
 var entities = new Entities();
+var CssSelectorParser = require('css-selector-parser').CssSelectorParser;
+var cssParser = new CssSelectorParser();
+cssParser.registerSelectorPseudos('has');
 
-// Use sticky flag for RegExps where supported. Support is indicated by the
-// RegExp.prototype.sticky flag being false, rather than undefined.
-// For v8, see https://code.google.com/p/v8/issues/detail?id=4342.
-var globalStickyFlags = RegExp.prototype.sticky === false ? 'gy' : 'g';
+// Match the remainder of a tag.
+var optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:\'[^\']*\'|"[^"]*"))?)*';
+var remainingTagAssertionPattern = '(?=' + optionalAttributePattern + '\\s*\\/?>)';
+var remainingTagCloseCapturePattern = optionalAttributePattern + '\\s*(\\/?)>';
 
 /**
  * Element matcher class.
  */
-
 function Matcher(spec) {
-    this._handlers = spec;
-    this._matchRe = new TagMatcher(spec);
-    //this._matchRe = this._compile(spec);
-}
-
-// Compile to a single regexp matching all registered tags.
-Matcher.prototype._compile = function(spec) {
-    var matchReString = '<\\/?(?:'
-        + Object.keys(spec)
-            .map(function(name) {
-                return name.replace(/\-/g, '\\-');
-            })
-            .join('|')
-        + ')(?=[ />])';
-    return new RegExp(matchReString, 'g');
-};
-
-
-/*
- * Alternative tag matcher (drop-in for _compile()), which lets us relax the
- * requirement for escaping `<` in attribute values by explicitly matching all
- * tags & implicitly keeping track of in-attribute state.
- *
- * Performance penalty for Obama: About 15% (1.85ms vs. 2.15ms)
- */
-var remainingTagPattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:\'[^\']*\'|"[^"]*"))?)*[\\s\\/]*>';
-function TagMatcher(spec) {
     this._spec = spec;
-    this.lastIndex = 0;
-    // Efficient matcher for tags we aren't interested in. Used to consume the
-    // bulk of the content, with tags consumed atomically. This avoids
-    // matching unadorned < in attribute values.
-    this._otherTagMatcher = new RegExp('(?:[^<>]*<\/?(?!'
-                    + Object.keys(spec).join('|')
-                    + ')[a-zA-Z_-]+' + remainingTagPattern + ')+',
-            globalStickyFlags);
-
-    // A matcher for the tags we *are* actually interested in.
-    this._ourTagMatcher = new RegExp('<(\\/?('
-                    + Object.keys(spec).join('|')
-                    + '))' + remainingTagPattern,
-            globalStickyFlags);
-}
-
-TagMatcher.prototype.exec = function(s) {
-    while (true) {
-        // Skip over other tags
-        this._otherTagMatcher.lastIndex = this.lastIndex;
-        var match = this._otherTagMatcher.exec(s);
-        // Try to match an actual tag
-        if (match.index === this.lastIndex) {
-            this._ourTagMatcher.lastIndex = this._otherTagMatcher.lastIndex;
-        } else {
-            this._ourTagMatcher.lastIndex = this.lastIndex;
-        }
-        match = this._ourTagMatcher.exec(s);
-        if (!match) {
-            return null;
-        } else if (this._spec[match[2]]) {
-            this.lastIndex = match.index + match[1].length + 1;
+    this._handlers = Object.keys(spec)
+        .map(function(key) {
             return {
-                0: '<' + match[1],
-                index: match.index,
+                handler: spec[key],
+                selector: key,
+                nodeName: null,
             };
-        }
-    }
-};
+        });
+    this._matchRe = this._makeMatcher(spec);
+    // Efficient matcher for random Tags.
+    this._anyTagMatcher = new RegExp('<(\/?)([a-zA-Z_-]+)'
+            + remainingTagCloseCapturePattern, 'g');
+}
 
 
 var ATTRIB_PATTERN = '\\s+([a-zA-Z][a-zA-Z_-]*)=(?:\'([^\']*)\'|"([^"]*)")|.';
-var ATTRIB = new RegExp(ATTRIB_PATTERN, globalStickyFlags);
+var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
+
+Matcher.prototype._makeMatcher = function(spec) {
+    var self = this;
+    this._spec = spec;
+    this.lastIndex = 0;
+    // Need:
+    // - Start tag matcher. Safe, as '<' is always escaped, including
+    // attributes.
+    // - Random tag matcher. Match as long as level reaches zero.
+
+
+    // A matcher for the tags we *are* actually interested in.
+    var ourTagRegex = '<(\\/?)(?:'
+                    + self._handlers
+                        .map(self._compileTagMatcher.bind(self))
+                        .join('|')
+                    + ')' + remainingTagAssertionPattern;
+    // console.log(ourTagRegex);
+    return new RegExp(ourTagRegex, 'g');
+};
+
+Matcher.prototype._compileTagMatcher = function(handler) {
+    var ruleSet = cssParser.parse(handler.selector);
+    //console.log(JSON.stringify(ruleSet, null, 2));
+    if (ruleSet.type !== 'ruleSet') {
+        throw new Error('Only simple attribute value matches like '
+                + 'a[href="foo"] supported for now!');
+    }
+    var tagName = ruleSet.rule.tagName;
+
+    if (!tagName) {
+        throw new Error("Only matches for fixed tag names are supported for now!");
+    }
+    // Remember the tag name as an attribute
+    handler.nodeName = tagName;
+    var attributes = ruleSet.rule.attrs;
+    var res = '(' + tagName || '';
+    if (attributes) {
+        if (attributes.length > 1) {
+            throw new Error("Only a single attribute match is supported for now!");
+        }
+        // Only match on the first attribute
+        var attr = attributes[0];
+        if (!attr.operator) {
+            res += '(?=[^>]*?\\s' + attr.name + '=["\'][^"\']*["\'])';
+        } else if (attr.operator === '=') {
+            res += '(?=[^>]*?\\s' + attr.name + '=["\']' + attr.value + '["\'])';
+        } else {
+            throw new Error("Unsupported attribute predicate: " + attr.operator);
+        }
+    }
+    res += ')';
+    // console.log(res);
+    return res;
+};
 
 Matcher.prototype._matchAttributes = function(s, index) {
     ATTRIB.lastIndex = index;
@@ -108,71 +112,89 @@ Matcher.prototype._matchAttributes = function(s, index) {
     };
 };
 
-var TAG_END = new RegExp('\\s*\/?>', globalStickyFlags);
+var TAG_END = new RegExp('\\s*\/?>', 'g');
 Matcher.prototype._matchTagEnd = function(s, index) {
     TAG_END.lastIndex = index;
     TAG_END.exec(s);
     return TAG_END.lastIndex;
 };
 
+Matcher.prototype.matchElement = function(s, results, handler, node) {
+    var depth = 1;
+    // console.log(node._dsr[1], s.slice(node._dsr[1], node._dsr[1] + 660));
+    this._anyTagMatcher.lastIndex = node._dsr[1];
+    while (true) {
+        var match = this._anyTagMatcher.exec(s);
+        if (!match) {
+            throw new Error('Did not find end tag for: ' + handler.nodeName);
+        }
+        if (match[1]) {
+            // End tag
+            depth--;
+            if (depth === 0) {
+                if (match[2] === handler.nodeName) {
+                    node.outerHTML = s.substring(node._dsr[0], this._anyTagMatcher.lastIndex);
+                    node.innerHTML = s.substring(node._dsr[1], match.index);
+
+                    // Add HTML string prefix since the previous match.
+                    results.push(s.substring(node._lastEndOffset, node._dsr[0]));
+
+                    // Call the handler
+                    results.push(handler.handler(node));
+                    return this._anyTagMatcher.lastIndex;
+                } else {
+                    throw new Error("Mis-matched end tag: Expected "
+                            + JSON.stringify(handler.nodeName)
+                            + ', got ' + JSON.stringify(match[2]) + '.');
+                }
+            }
+        } else if (!match[3]) {
+            // Start tag.
+            depth++;
+        }
+    }
+};
+
 Matcher.prototype.matchAll = function(s) {
     var results = [];
-    var stack = [];
     this._matchRe.lastIndex = 0;
     while (true) {
         var lastEndOffset = this._matchRe.lastIndex;
         var match = this._matchRe.exec(s);
 
         if (!match) {
+            // Add the HTML suffix, if any.
+            if (lastEndOffset !== s.length) {
+                results.push(s.slice(lastEndOffset, s.length));
+            }
             // Nothing left to process.
             break;
         }
-
-        var tagMatch = match[0];
-        if (/^<[a-zA-Z]/.test(tagMatch)) {
+        var tagMatch = match[1];
+        if (!match[1]) {
             // Start tag.
+            var handlerObj;
+            var tagMatch;
+            var i = 2;
+            for (; i < match.length; i++) {
+                tagMatch = match[i];
+                if (tagMatch !== undefined) {
+                    handlerObj = this._handlers[i-2];
+                    // console.log(tagMatch, handlerObj);
+                    break;
+                }
+            }
+            //var attributeStartOffset = match.index + tagMatch.length + 1;
             var attributeMatch = this._matchAttributes(s, this._matchRe.lastIndex);
-            this._matchRe.lastIndex = attributeMatch.endOffset;
-            stack.push({
-                nodeName: tagMatch.substr(1),
+            this._matchRe.lastIndex = this.matchElement(s, results, handlerObj, {
+                nodeName: handlerObj.nodeName,
                 attributes: attributeMatch.attributes,
                 _dsr: [match.index, attributeMatch.endOffset],
                 _lastEndOffset: lastEndOffset,
             });
-        } else {
-            // End tag.
-            var tagName = match[0].replace(/<\/?/, '');
-
-            if (stack.length > 0) {
-                // Find tag on stack, backwards
-                for (var i = stack.length - 1; i >= 0; i--) {
-                    // TODO: support nested tags?
-                    if (stack[i].nodeName === tagName && i === 0) {
-                        var node = stack[i];
-                        stack = stack.slice(0, i);
-
-                        // Match to the end of the end tag
-                        var endOffset = this._matchTagEnd(s, this._matchRe.lastIndex);
-                        this._matchRe.lastIndex = endOffset;
-                        node.outerHTML = s.substring(node._dsr[0], endOffset);
-                        node.innerHTML = s.substring(node._dsr[1], match.index);
-
-                        // Add HTML string prefix since the previous match.
-                        results.push(s.substring(node._lastEndOffset, node._dsr[0]));
-
-                        // Call the handler
-                        results.push(this._handlers[tagName](node));
-                        break;
-                    }
-                }
-            }
         }
     }
-
-    // Add the HTML suffix, if any.
-    if (this._matchRe.lastIndex < s.length) {
-        results.push(s.substring(this._matchRe.lastIndex, s.length));
-    }
+    // console.log(JSON.stringify(results, null, 2));
 
     return results;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,10 @@ Matcher.prototype._makeMatchers = function(spec) {
                     + ')' + remainingTagAssertionPattern, 'g');
 };
 
+function escapeRegex(re) {
+	return re.replace(/[\^\\$*+?.()|{}\[\]\/]/g, '\\$&');
+};
+
 var attrValReplacements = {
     'double': {
         '<': '(?:<|&lt;)',
@@ -87,6 +91,8 @@ attrValReplacements.single = Object.assign({},
 Matcher.prototype._quoteAttributeValue = function(s, mode) {
     if (/[<'">&]/.test(s)) {
         var map = attrValReplacements[mode];
+        // Escape any regexp chars in the value
+        s = escapeRegex(s);
         return s.replace(/[<'">&]/g, function(m) {
                 return map[m];
         });
@@ -124,27 +130,23 @@ Matcher.prototype._compileTagMatcher = function(handler) {
 
         var doubleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'double');
         var singleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'single');
-
+        res += '(?=[^>]*?\\s' + attr.name;
         if (!attr.operator) {
-            res += '(?=[^>]*?\\s' + attr.name + '=(?:"[^"]*"|\'[^\']*\'))';
+             res += '=(?:"[^"]*"|\'[^\']*\'))';
         } else if (attr.operator === '=') {
-            res += '(?=[^>]*?\\s' + attr.name + '=(?:"' + doubleQuoteValuePattern + '"|\''
+            res += '=(?:"' + doubleQuoteValuePattern + '"|\''
                         + singleQuoteValuePattern + '\'))';
         } else if (attr.operator === '^=') {
-            res += '(?=[^>]*?\\s' + attr.name
-                    + '=(?:"' + doubleQuoteValuePattern + '[^"]*"'
+            res += '=(?:"' + doubleQuoteValuePattern + '[^"]*"'
                     + '|\'' + singleQuoteValuePattern + '[^\']*\'))';
         } else if (attr.operator === '$=') {
-            res += '(?=[^>]*?\\s' + attr.name
-                    + '=(?:"[^"]*' + doubleQuoteValuePattern + '"'
+            res += '=(?:"[^"]*' + doubleQuoteValuePattern + '"'
                     + '|\'[^\']*' + singleQuoteValuePattern + '\'))';
         } else if (attr.operator === '~=') {
-            res += '(?=[^>]*?\\s' + attr.name
-                    + '=(?:"(?:[^"]+\\s+)*' + doubleQuoteValuePattern + '(?:\\s+[^"]+)*"'
+            res += '=(?:"(?:[^"]+\\s+)*' + doubleQuoteValuePattern + '(?:\\s+[^"]+)*"'
                     + "|'(?:[^']+\\s)*" + singleQuoteValuePattern + "(?:\\s[^']+)*'))";
         } else if (attr.operator === '*=') {
-            res += '(?=[^>]*?\\s' + attr.name
-                    + '=(?:"[^"]*' + doubleQuoteValuePattern + '[^"]*"'
+            res += '=(?:"[^"]*' + doubleQuoteValuePattern + '[^"]*"'
                     + "|'[^']*" + singleQuoteValuePattern + "[^']*'))";
         } else {
             throw new Error("Unsupported attribute predicate: " + attr.operator);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var Entities = require('html-entities').AllHtmlEntities;
-var entities = new Entities();
-var CssSelectorParser = require('css-selector-parser').CssSelectorParser;
-var cssParser = new CssSelectorParser();
+const Entities = require('html-entities').AllHtmlEntities;
+const entities = new Entities();
+const CssSelectorParser = require('css-selector-parser').CssSelectorParser;
+const cssParser = new CssSelectorParser();
 cssParser.registerSelectorPseudos('has');
 cssParser.registerAttrEqualityMods('^', '~', '$', '*');
 
 // Shared patterns
-var optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:"[^"]*"|\'[^\']*\'))?)*';
-var remainingTagAssertionPattern = '(?=' + optionalAttributePattern + '\\s*\\/?>)';
-var remainingTagCloseCapturePattern = optionalAttributePattern + '\\s*(\\/?)>';
-var remainingTagPattern = optionalAttributePattern + '\\s*\\/?>';
+const optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:"[^"]*"|\'[^\']*\'))?)*';
+const remainingTagAssertionPattern = '(?=' + optionalAttributePattern + '\\s*\\/?>)';
+const remainingTagCloseCapturePattern = optionalAttributePattern + '\\s*(\\/?)>';
+const remainingTagPattern = optionalAttributePattern + '\\s*\\/?>';
 
 
 /**
@@ -73,7 +73,7 @@ function escapeRegex(re) {
 	return re.replace(/[\^\\$*+?.()|{}\[\]\/]/g, '\\$&');
 }
 
-var attrValReplacements = {
+const attrValReplacements = {
     'double': {
         '<': '(?:<|&lt;)',
         '>': '(?:>|&gt;)',
@@ -105,9 +105,9 @@ Matcher.prototype._quoteAttributeValue = function(s, mode) {
 // Attribute names must consist of one or more characters other than the space
 // characters, U+0000 NULL, """, "'", ">", "/", "=", the control characters,
 // and any characters that are not defined by Unicode.
-var ATTRIB_NAME_PATTERN = '[^\\s\\0"\'>/=\x00-\x1F\x7F-\x9F]+';
-var ATTRIB_PATTERN = '\\s+(' + ATTRIB_NAME_PATTERN + ')=(?:"([^"]*)"|\'([^\']*)\')|';
-var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
+const ATTRIB_NAME_PATTERN = '[^\\s\\0"\'>/=\x00-\x1F\x7F-\x9F]+';
+const ATTRIB_PATTERN = '\\s+(' + ATTRIB_NAME_PATTERN + ')=(?:"([^"]*)"|\'([^\']*)\')|';
+const ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
 
 Matcher.prototype._matchAttributes = function(s, index) {
 
@@ -186,7 +186,7 @@ Matcher.prototype._compileTagMatcher = function(handler) {
     return res;
 };
 
-var TAG_END = new RegExp('\\s*\/?>|', 'g');
+const TAG_END = new RegExp('\\s*\/?>|', 'g');
 Matcher.prototype._matchTagEnd = function(s, index) {
     TAG_END.lastIndex = index;
     TAG_END.exec(s);

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ Matcher.prototype._makeMatchers = function(spec) {
 
 function escapeRegex(re) {
 	return re.replace(/[\^\\$*+?.()|{}\[\]\/]/g, '\\$&');
-};
+}
 
 var attrValReplacements = {
     'double': {
@@ -101,6 +101,36 @@ Matcher.prototype._quoteAttributeValue = function(s, mode) {
     }
 };
 
+// https://www.w3.org/TR/html-markup/syntax.html#syntax-attributes:
+// Attribute names must consist of one or more characters other than the space
+// characters, U+0000 NULL, """, "'", ">", "/", "=", the control characters,
+// and any characters that are not defined by Unicode.
+var ATTRIB_NAME_PATTERN = '[^\\s\\0"\'>/=\x00-\x1F\x7F-\x9F]+';
+var ATTRIB_PATTERN = '\\s+(' + ATTRIB_NAME_PATTERN + ')=(?:"([^"]*)"|\'([^\']*)\')|';
+var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
+
+Matcher.prototype._matchAttributes = function(s, index) {
+
+    ATTRIB.lastIndex = index;
+    var attributes = {};
+    while (true) {
+        var match = ATTRIB.exec(s);
+        if (match[0].length === 0) {
+            break;
+        }
+        var val = match[2] || match[3];
+        if (/&/.test(val)) {
+            // Decode HTML entities
+            val = entities.decode(val);
+        }
+        attributes[match[1]] = val;
+    }
+    return {
+        attributes: attributes,
+        endOffset: this._matchTagEnd(s, ATTRIB.lastIndex || index),
+    };
+};
+
 Matcher.prototype._compileTagMatcher = function(handler) {
     var ruleSet = cssParser.parse(handler.selector);
     //console.log(JSON.stringify(ruleSet, null, 2));
@@ -128,9 +158,9 @@ Matcher.prototype._compileTagMatcher = function(handler) {
         var value = attr.value || '';
 
 
+        res += '(?=[^>]*?\\s' + attr.name;
         var doubleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'double');
         var singleQuoteValuePattern = this._quoteAttributeValue(attr.value, 'single');
-        res += '(?=[^>]*?\\s' + attr.name;
         if (!attr.operator) {
              res += '=(?:"[^"]*"|\'[^\']*\'))';
         } else if (attr.operator === '=') {
@@ -154,31 +184,6 @@ Matcher.prototype._compileTagMatcher = function(handler) {
     }
     // console.log(res);
     return res;
-};
-
-var ATTRIB_PATTERN = '\\s+([a-zA-Z][a-zA-Z_-]*)=(?:"([^"]*)"|\'([^\']*)\')|';
-var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
-
-Matcher.prototype._matchAttributes = function(s, index) {
-
-    ATTRIB.lastIndex = index;
-    var attributes = {};
-    while (true) {
-        var match = ATTRIB.exec(s);
-        if (match[0].length === 0) {
-            break;
-        }
-        var val = match[2] || match[3];
-        if (/&/.test(val)) {
-            // Decode HTML entities
-            val = entities.decode(val);
-        }
-        attributes[match[1]] = val;
-    }
-    return {
-        attributes: attributes,
-        endOffset: this._matchTagEnd(s, ATTRIB.lastIndex || index),
-    };
 };
 
 var TAG_END = new RegExp('\\s*\/?>|', 'g');

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,15 +6,19 @@ var CssSelectorParser = require('css-selector-parser').CssSelectorParser;
 var cssParser = new CssSelectorParser();
 cssParser.registerSelectorPseudos('has');
 
-// Match the remainder of a tag.
-var optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:\'[^\']*\'|"[^"]*"))?)*';
+// Shared patterns
+var optionalAttributePattern = '(?:\\s+[a-zA-Z_-]+(?:=(?:"[^"]*"|\'[^\']*\'))?)*';
 var remainingTagAssertionPattern = '(?=' + optionalAttributePattern + '\\s*\\/?>)';
 var remainingTagCloseCapturePattern = optionalAttributePattern + '\\s*(\\/?)>';
+var remainingTagPattern = optionalAttributePattern + '\\s*\\/?>';
+
 
 /**
  * Element matcher class.
  */
 function Matcher(spec) {
+    // TODO: Move spec format closer to _handlers, so that we can accept
+    // selectors as both string & object.
     this._spec = spec;
     this._handlers = Object.keys(spec)
         .map(function(key) {
@@ -24,17 +28,13 @@ function Matcher(spec) {
                 nodeName: null,
             };
         });
-    this._matchRe = this._makeMatcher(spec);
+    this._makeMatchers(spec);
     // Efficient matcher for random Tags.
     this._anyTagMatcher = new RegExp('<(\/?)([a-zA-Z_-]+)'
             + remainingTagCloseCapturePattern, 'g');
 }
 
-
-var ATTRIB_PATTERN = '\\s+([a-zA-Z][a-zA-Z_-]*)=(?:\'([^\']*)\'|"([^"]*)")|.';
-var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
-
-Matcher.prototype._makeMatcher = function(spec) {
+Matcher.prototype._makeMatchers = function(spec) {
     var self = this;
     this._spec = spec;
     this.lastIndex = 0;
@@ -44,14 +44,28 @@ Matcher.prototype._makeMatcher = function(spec) {
     // - Random tag matcher. Match as long as level reaches zero.
 
 
-    // A matcher for the tags we *are* actually interested in.
-    var ourTagRegex = '<(\\/?)(?:'
-                    + self._handlers
-                        .map(self._compileTagMatcher.bind(self))
+    var tagMatchPatterns = self._handlers
+            .map(function(handler) {
+                return self._compileTagMatcher(handler);
+            });
+
+    // A matcher for the tags we are *not* interested in. Used in HTML5 mode.
+    this._otherTagRe = new RegExp('[^<]*(?:<[\\/! ]*(?!'
+                    + tagMatchPatterns
+                        .map(function(pattern) {
+                            return '(?:' + pattern + ')';
+                        })
                         .join('|')
-                    + ')' + remainingTagAssertionPattern;
-    // console.log(ourTagRegex);
-    return new RegExp(ourTagRegex, 'g');
+                    + ')[a-zA-Z][a-zA-Z_-]*' + remainingTagPattern + '[^<]*)+', 'g');
+
+    // A matcher for the tags we *are* actually interested in.
+    this._matchRe = new RegExp('<(\\/?)(?:'
+                    + tagMatchPatterns
+                        .map(function(pattern) {
+                            return '(' + pattern + ')';
+                        })
+                        .join('|')
+                    + ')' + remainingTagAssertionPattern, 'g');
 };
 
 Matcher.prototype._compileTagMatcher = function(handler) {
@@ -69,7 +83,7 @@ Matcher.prototype._compileTagMatcher = function(handler) {
     // Remember the tag name as an attribute
     handler.nodeName = tagName;
     var attributes = ruleSet.rule.attrs;
-    var res = '(' + tagName || '';
+    var res = tagName || '';
     if (attributes) {
         if (attributes.length > 1) {
             throw new Error("Only a single attribute match is supported for now!");
@@ -84,19 +98,20 @@ Matcher.prototype._compileTagMatcher = function(handler) {
             throw new Error("Unsupported attribute predicate: " + attr.operator);
         }
     }
-    res += ')';
     // console.log(res);
     return res;
 };
 
+var ATTRIB_PATTERN = '\\s+([a-zA-Z][a-zA-Z_-]*)=(?:"([^"]*)"|\'([^\']*)\')|';
+var ATTRIB = new RegExp(ATTRIB_PATTERN, 'g');
+
 Matcher.prototype._matchAttributes = function(s, index) {
+
     ATTRIB.lastIndex = index;
     var attributes = {};
     while (true) {
-        var startIndex = ATTRIB.lastIndex;
         var match = ATTRIB.exec(s);
-        if (!match || match[0].length === 1) {
-            ATTRIB.lastIndex = startIndex;
+        if (match[0].length === 0) {
             break;
         }
         var val = match[2] || match[3];
@@ -112,7 +127,7 @@ Matcher.prototype._matchAttributes = function(s, index) {
     };
 };
 
-var TAG_END = new RegExp('\\s*\/?>', 'g');
+var TAG_END = new RegExp('\\s*\/?>|', 'g');
 Matcher.prototype._matchTagEnd = function(s, index) {
     TAG_END.lastIndex = index;
     TAG_END.exec(s);
@@ -155,11 +170,22 @@ Matcher.prototype.matchElement = function(s, results, handler, node) {
     }
 };
 
-Matcher.prototype.matchAll = function(s) {
+Matcher.prototype.matchAll = function(s, options) {
+    var isXML = options && options.isXML;
     var results = [];
     this._matchRe.lastIndex = 0;
     while (true) {
         var lastEndOffset = this._matchRe.lastIndex;
+
+        if (!isXML) {
+            // Explicitly match tags & attributes to avoid matching literal
+            // `<` in attribute values. These are escaped with `&lt;` in XML,
+            // but not HTML5.
+            this._otherTagRe.lastIndex = this._matchRe.lastIndex;
+            this._otherTagRe.exec(s);
+            this._matchRe.lastIndex = this._otherTagRe.lastIndex;
+        }
+
         var match = this._matchRe.exec(s);
 
         if (!match) {
@@ -170,7 +196,7 @@ Matcher.prototype.matchAll = function(s) {
             // Nothing left to process.
             break;
         }
-        var tagMatch = match[1];
+
         if (!match[1]) {
             // Start tag.
             var handlerObj;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "domino": "^1.0.23"
   },
   "dependencies": {
-    "html-entities": "^1.2.0"
+    "css-selector-parser": "^1.1.0",
+    "html-entities": "^1.2.0",
+    "install": "^0.6.1",
+    "npm": "^3.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   },
   "dependencies": {
     "css-selector-parser": "^1.1.0",
-    "html-entities": "^1.2.0",
-    "install": "^0.6.1",
-    "npm": "^3.8.6"
+    "html-entities": "^1.2.0"
   }
 }

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var assert = require('assert');
+
+var ElementMatcher = require('../lib/index');
+
+var htmlparser2 = require('htmlparser2');
+var libxmljs = require("libxmljs");
+var domino = require('domino');
+
+function id(n) { return n; }
+var figures = 0;
+var links = 0;
+function figure(n) { figures++; return n; }
+function link(n) { links++; return n; }
+
+function bench() {
+    var obama = fs.readFileSync('test/obama.html', 'utf8');
+    var startTime = Date.now();
+    var linkMatcher = new ElementMatcher({
+        'a': link,
+    });
+    var n = 200;
+    for (var i = 0; i < n; i++) {
+        linkMatcher.matchAll(obama);
+    }
+    console.log(links / n);
+    console.log((Date.now() - startTime) / n + 'ms per match');
+}
+
+if (!module.parent) {
+    bench();
+}

--- a/test/index.js
+++ b/test/index.js
@@ -24,10 +24,6 @@ var matcher = new ElementMatcher({
     'figure': figure,
 });
 
-var linkMatcher = new ElementMatcher({
-    'a': link,
-});
-
 var referencesMatcher = new ElementMatcher({
     'ol[typeof="mw:Extension/references"]': link,
 });
@@ -81,13 +77,25 @@ module.exports = {
             assert.equal(nodes[2], '<div class="a"></div>'+ testFooter);
         }
     },
-    "performance": {
+    "performance, figures": {
         "Obama": function() {
             var obama = fs.readFileSync('test/obama.html', 'utf8');
             var startTime = Date.now();
-            var n = 20;
+            var n = 200;
             for (var i = 0; i < n; i++) {
                 matcher.matchAll(obama);
+            }
+            console.log(figures);
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, figures, XML mode": {
+        "Obama": function() {
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            var startTime = Date.now();
+            var n = 200;
+            for (var i = 0; i < n; i++) {
+                matcher.matchAll(obama, { isXML: true });
             }
             console.log(figures);
             console.log((Date.now() - startTime) / n + 'ms per match');
@@ -97,9 +105,28 @@ module.exports = {
         "Obama": function() {
             var obama = fs.readFileSync('test/obama.html', 'utf8');
             var startTime = Date.now();
-            var n = 10;
+            var linkMatcher = new ElementMatcher({
+                'a': link,
+            });
+            var n = 100;
             for (var i = 0; i < n; i++) {
                 linkMatcher.matchAll(obama);
+            }
+            console.log(links / n);
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, links, XML mode": {
+        "Obama": function() {
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            links = 0;
+            var startTime = Date.now();
+            var linkMatcher = new ElementMatcher({
+                'a': link,
+            });
+            var n = 100;
+            for (var i = 0; i < n; i++) {
+                linkMatcher.matchAll(obama, { isXML: true });
             }
             console.log(links / n);
             console.log((Date.now() - startTime) / n + 'ms per match');
@@ -112,9 +139,23 @@ module.exports = {
             });
             var obama = fs.readFileSync('test/obama.html', 'utf8');
             var startTime = Date.now();
-            var n = 10;
+            var n = 50;
             for (var i = 0; i < n; i++) {
                 specificLinkMatcher.matchAll(obama);
+            }
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, specific link, XML mode": {
+        "Obama": function() {
+            var specificLinkMatcher = new ElementMatcher({
+                'a[href="./Riverdale,_Chicago"]': link,
+            });
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            var startTime = Date.now();
+            var n = 50;
+            for (var i = 0; i < n; i++) {
+                specificLinkMatcher.matchAll(obama, { isXML: true });
             }
             console.log((Date.now() - startTime) / n + 'ms per match');
         }
@@ -126,6 +167,17 @@ module.exports = {
             var n = 10;
             for (var i = 0; i < n; i++) {
                 referencesMatcher.matchAll(obama);
+            }
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, references, isXML": {
+        "Obama": function() {
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            var startTime = Date.now();
+            var n = 10;
+            for (var i = 0; i < n; i++) {
+                referencesMatcher.matchAll(obama, { isXML: true });
             }
             console.log((Date.now() - startTime) / n + 'ms per match');
         }

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,7 @@ function innerHTML(s) {
 
 var testHead = "<doctype html><head><title>hello</title></head><body>\n";
 var testFooter = "</body>";
-var customElement = "<test-element foo='bar &lt;figure &gt;' baz=\"booz\">"
+var customElement = "<test-element foo='bar &lt;figure &gt;' baz=\"booz baax boooz\">"
             + "<foo-bar></foo-bar><figure>hello</figure></test-element>";
 
 var testDoc = testHead + customElement + testFooter;
@@ -49,7 +49,7 @@ module.exports = {
             assert.equal(n1.outerHTML, customElement);
             assert.deepEqual(n1.attributes, {
                 foo: 'bar <figure >',
-                baz: 'booz'
+                baz: 'booz baax boooz'
             });
             assert.equal(nodes[2], testFooter);
         },
@@ -72,10 +72,203 @@ module.exports = {
             assert.equal(n1.outerHTML, customElement);
             assert.deepEqual(n1.attributes, {
                 foo: 'bar <figure >',
-                baz: 'booz'
+                baz: 'booz baax boooz'
             });
             assert.equal(nodes[2], '<div class="a"></div>'+ testFooter);
-        }
+        },
+    },
+    'presence': {
+        "attribute presence": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "attribute presence, no match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[bar]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+    },
+    'equality': {
+        "match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo="bar <figure >"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "no value match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo="boo"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+        "no attribute of name": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[bar="booz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+    },
+    'prefix': {
+        "match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo^="bar <figure"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "no value match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo^="boo"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+        "no attribute of name": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[bar^="booz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+    },
+    'space-delimited attribute': {
+        "match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo~="bar"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "match, middle": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[baz~="baax"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "match, end": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[baz~="boooz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "no value match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo~="boo"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+        "no attribute of name": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[bar~="booz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+    },
+    'suffix': {
+        "match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo$="figure >"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "another match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[baz$=" boooz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testHead);
+            var n1 = nodes[1];
+            assert.equal(n1.innerHTML, '<foo-bar></foo-bar><figure>hello</figure>');
+            assert.equal(n1.outerHTML, customElement);
+            assert.deepEqual(n1.attributes, {
+                foo: 'bar <figure >',
+                baz: 'booz baax boooz'
+            });
+            assert.equal(nodes[2], testFooter);
+        },
+        "no value match": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[foo$="figure"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
+        "space-delim attribute match, no attribute of name": function() {
+            var attribMatcher = new ElementMatcher({
+                'test-element[bar~="boooz"]': id,
+            });
+            var nodes = attribMatcher.matchAll(testDoc);
+            assert.equal(nodes[0], testDoc);
+        },
     },
     "performance, figures": {
         "Obama": function() {

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,8 @@ var links = 0;
 function figure(n) { figures++; return n; }
 function link(n) { links++; return n; }
 
+// XML enscaping rules: https://www.w3.org/TR/xml/#syntax
+
 var matcher = new ElementMatcher({
     'test-element': id,
     'foo-bar': id,
@@ -26,13 +28,17 @@ var linkMatcher = new ElementMatcher({
     'a': link,
 });
 
+var referencesMatcher = new ElementMatcher({
+    'ol[typeof="mw:Extension/references"]': link,
+});
+
 function innerHTML(s) {
     return s.replace(/^<[^>]+>(.*)<\/[^>]+>$/, '$1');
 }
 
-var testHead = "<doctype html><head><title>hello</title></head>\n";
-var testFooter = "<body></body>";
-var customElement = "<test-element foo='bar <figure >' baz=\"booz\">"
+var testHead = "<doctype html><head><title>hello</title></head><body>\n";
+var testFooter = "</body>";
+var customElement = "<test-element foo='bar &lt;figure &gt;' baz=\"booz\">"
             + "<foo-bar></foo-bar><figure>hello</figure></test-element>";
 
 var testDoc = testHead + customElement + testFooter;
@@ -96,6 +102,31 @@ module.exports = {
                 linkMatcher.matchAll(obama);
             }
             console.log(links / n);
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, specific link": {
+        "Obama": function() {
+            var specificLinkMatcher = new ElementMatcher({
+                'a[href="./Riverdale,_Chicago"]': link,
+            });
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            var startTime = Date.now();
+            var n = 10;
+            for (var i = 0; i < n; i++) {
+                specificLinkMatcher.matchAll(obama);
+            }
+            console.log((Date.now() - startTime) / n + 'ms per match');
+        }
+    },
+    "performance, references": {
+        "Obama": function() {
+            var obama = fs.readFileSync('test/obama.html', 'utf8');
+            var startTime = Date.now();
+            var n = 10;
+            for (var i = 0; i < n; i++) {
+                referencesMatcher.matchAll(obama);
+            }
             console.log((Date.now() - startTime) / n + 'ms per match');
         }
     },

--- a/test/index.js
+++ b/test/index.js
@@ -104,6 +104,7 @@ module.exports = {
     "performance, links": {
         "Obama": function() {
             var obama = fs.readFileSync('test/obama.html', 'utf8');
+            links = 0;
             var startTime = Date.now();
             var linkMatcher = new ElementMatcher({
                 'a': link,
@@ -153,7 +154,7 @@ module.exports = {
             });
             var obama = fs.readFileSync('test/obama.html', 'utf8');
             var startTime = Date.now();
-            var n = 50;
+            var n = 100;
             for (var i = 0; i < n; i++) {
                 specificLinkMatcher.matchAll(obama, { isXML: true });
             }
@@ -164,7 +165,7 @@ module.exports = {
         "Obama": function() {
             var obama = fs.readFileSync('test/obama.html', 'utf8');
             var startTime = Date.now();
-            var n = 10;
+            var n = 100;
             for (var i = 0; i < n; i++) {
                 referencesMatcher.matchAll(obama);
             }


### PR DESCRIPTION
This patch adds basic attribute matching support, using CSS selector syntax:

```css
a[href="/some/example"]
```

Current limitations:

- Element names need to be fixed, no matches for attributes only.
- Only exact matches (`=`).
- Only a single attribute selector.

All of these limitations can be lifted in principle.

Performance is very promising, with plain match performance slightly improving
over the previous code, and targeted matches for specific attribute values (a
specific link) on a 1.5mb HTML document ([[Barack Obama]]) taking 2.1ms.